### PR TITLE
Fix month correction svyDateUtils.getAge()

### DIFF
--- a/svyUtils/svyDateUtils.js
+++ b/svyUtils/svyDateUtils.js
@@ -561,6 +561,7 @@ function getAge(birthdate, compareDate) {
 		var dayOfMonth = now.get(java.util.Calendar.DAY_OF_MONTH);
 		now.add(java.util.Calendar.MONTH, -1);
 		days = now.getActualMaximum(java.util.Calendar.DAY_OF_MONTH) - birthDay.get(java.util.Calendar.DAY_OF_MONTH) + dayOfMonth;
+		months--;
 	} else {
 		days = 0;
 		if (months == 12) {


### PR DESCRIPTION
Fixes issue where month correction is not done when the day of month of the comparedate is smaller than day of month of the birthday.

**Example (result before fix):**
`scopes.svyDateUtils.getAge(new Date(2020,1,29),new Date(2020,2,1));`
{years:0.0,months:1.0,days:1.0}